### PR TITLE
Dockerfile: allow to parametrize which command is executed inside docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,5 +43,5 @@ RUN pwd
 
 ENV FORCE_UNSAFE_CONFIGURE=1
 
-ENTRYPOINT ["/bin/bash"]
+ENTRYPOINT ["/bin/bash","-c"]
 # CMD ["./site/build.sh", "-v"] 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ Use the following commands on the host to create and run the docker image:
     docker build -t ffmd-v2016.2.7 .
     docker run -it --name ffmd ffmd-v2016.2.7
 
+to run arbitrary commands inside the container you can:
+   docker run ffmd-v2016.2.7 "make update && ./buildOnly.sh && echo BUILD SUCCESSFUL"
+
 To restart the image once it has been stopped:
 
     docker start -i ffmd


### PR DESCRIPTION
This fixes #6
Edit: After seeing #7 I guess I should comment on this PR:

This allows to parametrize the command to be run inside the container while not requiring that the container is changed if new parameters are introduced.
Run this via docker run image "command that needs --to --be run --with params && echo jooooooo"