### PR TITLE
Use build script from site-ffmd.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,4 +46,5 @@ RUN pwd
 ENV FORCE_UNSAFE_CONFIGURE=1
 
 ENTRYPOINT ["/bin/bash","-c"]
-CMD ["cd /gluon && make update && for i in ar71xx-generic ar71xx-tiny; do GLUON_TARGET=$i make -j4 || make V=s && break; done"]
+#CMD ["cd /gluon && make update && for i in ar71xx-generic ar71xx-tiny; do GLUON_TARGET=$i make -j4 || make V=s && break; done"]
+CMD ["cd /gluon && make update && site/build.sh -y"]

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The build process can be configured with build arguments:
 
 To start the container with an arbitrary command, you can:
 
-	docker run --name ffmd ffmd-v2016.2.7 "/bin/bash"
+	docker run -it --name ffmd ffmd-v2016.2.7 "/bin/bash"
 
 You can run a shell in an existing container with the following command:
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The build process can be configured with build arguments:
 
 To start the container with an arbitrary command, you can:
 
-	docker run --name ffmd ffmd-v2016.2.7 "make update && ./buildOnly.sh && echo BUILD SUCCESSFUL"
+	docker run --name ffmd ffmd-v2016.2.7 "/bin/bash"
 
 You can run a shell in an existing container with the following command:
 


### PR DESCRIPTION
As mentioned in #9, this PR will change the docker command to running the build script from site-ffmd.
Additionally, the readme documents a call to bash for generic use of the container.

Discussion from @christf 
> I had this in there but was faced with an exiting build-script that
would require debugging. I didn't put in the effort because the script
is run with set -e and I suggested pooling our resources for biulding
gluon with frankfurt altogether. Hence, I was planning on leaving this
step for a later stage.
(see https://github.com/FreifunkMD/gluon-docker/pull/9#issuecomment-389610776)