### PR TITLE
Add ecdsautils package to build environment.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN DEBIAN_FRONTEND=noninteractive \
     apt-get -y upgrade && \
     apt-get -y install \
         build-essential \
+        ecdsautils \
         gawk \
         git \
         libncurses-dev \


### PR DESCRIPTION
These utils are missing when packages are signed within the bulid
environment.